### PR TITLE
Fix request full_url deprecation bug.

### DIFF
--- a/gcs-signed-url-example.py
+++ b/gcs-signed-url-example.py
@@ -149,7 +149,7 @@ def ProcessResponse(r, expected_status=200):
     SystemExit if the response code doesn't match expected_status.
   """
   print '--- Request ---'
-  print r.request.full_url
+  print r.request.url
   for header, value in r.request.headers.iteritems():
     print '%s: %s' % (header, value)
   print '---------------'


### PR DESCRIPTION
`full_url` is no longer used in the `requests` library.

Before this change you would get error:
`AttributeError: 'PreparedRequest' object has no attribute 'full_url'`